### PR TITLE
Disable legacy SSL protocols

### DIFF
--- a/host_vars/matrix.pikaviestin.fi/main.yml
+++ b/host_vars/matrix.pikaviestin.fi/main.yml
@@ -91,6 +91,8 @@ synapse_workers:
 nginx:
   http:
     server_tokens: 'off'
+  ssl:
+    ssl_protocols: 'TLSv1.2 TLSv1.3'
 
 nginx_upstreams:
   authentik:


### PR DESCRIPTION
Security enhancement: TLSv1.0 and TLSv1.1 shouldn't be used anymore.